### PR TITLE
ci(goreleaser): include tests/stdlibs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,6 +147,8 @@ FROM        base AS gnocontribs
 COPY        --from=build-gnobro /gnoroot/build/gnobro                       /usr/bin/gnobro
 COPY        --from=build-contribs /gnoroot/build/gnogenesis                 /usr/bin/gnogenesis
 COPY        --from=build-gno /gnoroot/examples                              /gnoroot/examples
+COPY        --from=build-gno /gnoroot/gnovm/stdlibs                         /gnoroot/gnovm/stdlibs
+COPY        --from=build-gno /gnoroot/gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 COPY        --from=build-gno /gnoroot/gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 EXPOSE     22

--- a/Dockerfile.release
+++ b/Dockerfile.release
@@ -77,6 +77,8 @@ FROM base AS gnocontribs
 COPY       ./gnobro                                /usr/bin/gnobro
 COPY       ./gnogenesis                            /usr/bin/gnogenesis
 COPY       ./examples                              /gnoroot/examples/
+COPY       ./gnovm/stdlibs                         /gnoroot/gnovm/stdlibs/
+COPY       ./gnovm/tests/stdlibs                   /gnoroot/gnovm/tests/stdlibs/
 COPY       ./gno.land/genesis/genesis_balances.txt /gnoroot/gno.land/genesis/genesis_balances.txt
 COPY       ./gno.land/genesis/genesis_txs.jsonl    /gnoroot/gno.land/genesis/genesis_txs.jsonl
 EXPOSE     22


### PR DESCRIPTION
Add `gnovm` folders back to `gnocontribs` Docker image.